### PR TITLE
[IMPROVEMENT] add list chart type

### DIFF
--- a/components/Chart.vue
+++ b/components/Chart.vue
@@ -49,6 +49,10 @@
       :data="chartData"
       :options="chartOptions"
     />
+    <List
+      v-if="options.type === 'LIST'"
+      :data="chartData"
+    />
   </div>
 </template>
 

--- a/components/List.vue
+++ b/components/List.vue
@@ -1,0 +1,38 @@
+<template>
+  <div>
+    <ul> 
+      <li v-for="(item, i) in constructedData" :key="item.label">
+        {{ i + 1 }}.
+        <span>{{ item.label}}</span>
+        ({{ item.amount }})
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+
+// These definitions are a little weird but they are designed to 
+// provide a similar api to chartjs 
+const props = defineProps<{
+  data: {
+    datasets: {
+      data: number[];
+    }[]
+    labels: string[]
+  }
+}>()
+
+const constructedData = computed(() => {
+  if (props.data.datasets[0].data.length !== props.data.labels.length) {
+    throw new Error("Invalid data passed to list component")
+  }
+  const data = props.data.datasets[0].data.map((amount, index) => {
+    return {
+      amount,
+      label: props.data.labels[index]
+    }
+  });
+  return data.sort((a, b) => b.amount - a.amount)
+})
+</script>

--- a/prisma/migrations/20240401051353_add_list_type_to_chart/migration.sql
+++ b/prisma/migrations/20240401051353_add_list_type_to_chart/migration.sql
@@ -1,0 +1,11 @@
+-- AlterEnum
+ALTER TYPE "ChartType" ADD VALUE 'LIST';
+
+-- AlterTable
+ALTER TABLE "Event" ALTER COLUMN "end" SET DEFAULT NOW() + interval '1.5 hours';
+
+-- CreateIndex
+CREATE INDEX "Friend_user_id_idx" ON "Friend"("user_id");
+
+-- CreateIndex
+CREATE INDEX "Game_user_id_idx" ON "Game"("user_id");

--- a/prisma/migrations/20240401051353_add_list_type_to_chart/migration.sql
+++ b/prisma/migrations/20240401051353_add_list_type_to_chart/migration.sql
@@ -1,11 +1,2 @@
 -- AlterEnum
 ALTER TYPE "ChartType" ADD VALUE 'LIST';
-
--- AlterTable
-ALTER TABLE "Event" ALTER COLUMN "end" SET DEFAULT NOW() + interval '1.5 hours';
-
--- CreateIndex
-CREATE INDEX "Friend_user_id_idx" ON "Friend"("user_id");
-
--- CreateIndex
-CREATE INDEX "Game_user_id_idx" ON "Game"("user_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -309,6 +309,7 @@ enum ChartType {
   BAR
   PIE
   POLAR_AREA
+  LIST
 }
 
 enum DataField {


### PR DESCRIPTION
Added a simple list type to charts. This is very basic and some of the options could be utilised better (ie width and height don't make much sense as is as it does not expand to fill the area or anything)

I've used a slightly weird interface to try and match the chartjs implementation. 

Unsure if perhaps a table type would be better? (or maybe thats better as a seperate option

![image](https://github.com/lindsaykwardell/clocktracker/assets/16837325/8e0ae370-6382-4025-97ac-92ccbc8db0ed)

note: I manually edited the migration as my local prisma keeps wanting to add in an event migration so might need to double check that this is all ok

Feel free to reject if you don't like this
