### PR TITLE
[FIX] fix neverending migration on events

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -359,7 +359,7 @@ model Event {
   id                 String             @id @default(uuid())
   created_at         DateTime           @default(now()) @db.Timestamptz(6)
   start              DateTime           @default(now()) @db.Timestamptz(6)
-  end                DateTime           @default(dbgenerated("NOW() + interval '1.5 hours'")) @db.Timestamptz(6)
+  end                DateTime           @default(dbgenerated("(now() + '01:30:00'::interval)")) @db.Timestamptz(6)
   title              String
   description        String
   player_count       Int?


### PR DESCRIPTION
Fixes this migration always showing up, seems prisma couldn't detect the slighty difference in syntax so would always re-add it. Fixed this by using the same syntax that is generated from a `prisma db pull`