### PR TITLE
Fix BGStats import

### DIFF
--- a/composables/useBGStats.ts
+++ b/composables/useBGStats.ts
@@ -48,6 +48,7 @@ export const useBGStats = (g: ComputedRef<FetchStatus<GameRecord>>) => {
             ...game.grimoire[game.grimoire.length - 1].tokens
               .filter((token) => token.player_name)
               .map((token) => ({
+                startPlayer: false,
                 name: token.player_name.replace("@", ""),
                 role: `${token.alignment} - ${token.role?.name}`,
                 sourcePlayerId: token.player_name,


### PR DESCRIPTION
When using the "Post to BGStats" function, the BGStats app yields following error:

> Invalid data: org.json.JSONException: No value for startPlayer

The [official BGStats resource](https://www.bgstatsapp.com/support/push-plays-to-bg-stats-from-other-apps-or-websites/) lists the `startPlayer``field as not optional.

This PR extends every player map entry by this value, hard-setting it to `false` as it is irrelevant in BotC, but required.