### PR TITLE
Fix Capitalisation in BGStats Import

### DIFF
--- a/composables/useBGStats.ts
+++ b/composables/useBGStats.ts
@@ -39,7 +39,7 @@ export const useBGStats = (g: ComputedRef<FetchStatus<GameRecord>>) => {
         highestWins: false,
         name: "Blood on the Clocktower",
         noPoints: true,
-        sourceGameid: 240980,
+        sourceGameId: 240980,
       },
       board: game.script,
       playDate: dayjs(game.date).format("YYYY-MM-DD HH:mm:ss"),


### PR DESCRIPTION
I'm a bit annoyed that the JSON parser doesn't give a full list of errors. While Fix #299 is correct, there were more JSON errors:

This time, upon trying to import, `sourcePlayerId missing` is yielded. This time, it's just a capitalisation error (JSON is case sensitive).

To not repeat this again, I properly tested the fix and the corrected URL now leads to a successful import. So this time actually confirmed as working.