### PR TITLE
Fix BGStats Import if Storyteller is set

### DIFF
--- a/composables/useBGStats.ts
+++ b/composables/useBGStats.ts
@@ -60,6 +60,7 @@ export const useBGStats = (g: ComputedRef<FetchStatus<GameRecord>>) => {
               })),
             game.is_storyteller || game.storyteller?.length
               ? {
+                  startPlayer: false,
                   name: game.is_storyteller
                     ? game.user.username
                     : game.storyteller?.replace("@", "") || "",
@@ -73,6 +74,7 @@ export const useBGStats = (g: ComputedRef<FetchStatus<GameRecord>>) => {
           ]
         : [
             {
+              startPlayer: false,
               name: game.user.username,
               role: game.is_storyteller
                 ? "Storyteller"


### PR DESCRIPTION
The games I tested fix #299 on, didn't have a storyteller in them, thus I didn't notice they are handled separately. Third time's the charm, I guess...