### PR TITLE
Display the winning team on the last page of the grimoire

### DIFF
--- a/pages/game/[id]/index.vue
+++ b/pages/game/[id]/index.vue
@@ -422,6 +422,16 @@
               :canClaimSeat="canClaimSeat"
               @claimSeat="claimSeat"
             />
+            <div
+              v-if="grimPage === game.data.grimoire.length - 1"
+              class="winning-team"
+              :class="game.data?.win_v2 === WinStatus_V2.GOOD_WINS ? 'good' : 'evil'"
+            >
+              <span>
+                {{ game.data?.win_v2 === WinStatus_V2.GOOD_WINS ? 'Good' : 'Evil' }}
+              </span>
+              won!
+            </div>
           </div>
           <div
             class="text-center bg-gradient-to-b from-transparent via-stone-800 to-stone-800"
@@ -1061,6 +1071,39 @@ const tour = [
 .custom-script {
   background-image: url("/img/custom-script-bg.webp");
 }
+
+.winning-team {
+  position: absolute;
+  inset-block-start: 50%;
+  inset-inline-start: 50%;
+  transform: translate(-50%, -50%);
+  font-size: clamp(1.944rem, 1.7405rem + 0.9044vw, 2.4414rem);
+  font-family: "Times New Roman", serif;
+  font-weight: 500;
+  text-transform: uppercase;
+  text-align: center;
+  filter: drop-shadow(0 1px .25rem #000);
+  line-height: .8;
+
+  &.evil {
+    --color-winner-start: #ee4a05;
+    --color-winner-end: #cc1a04;
+  }
+  
+  &.good {
+    --color-winner-start: #4ec4ea;
+    --color-winner-end: #3186e4;
+  }
+
+  > span {
+    display: block;
+    font-size: clamp(2.3328rem, 1.5393rem + 3.5267vw, 4.2725rem);
+    background-image: linear-gradient(0deg, var(--color-winner-end), var(--color-winner-start));
+    background-clip: text;
+    color: transparent;
+  }
+}
+
 </style>
 
 <style>


### PR DESCRIPTION
Display the winning team, similar to the BotC app, on the last grimoire page of a game detail.
Discord issue: https://discord.com/channels/1129109427044233327/1432665751189458944

<img width="818" height="740" alt="image" src="https://github.com/user-attachments/assets/7da55be9-84c6-4f7c-8413-17294e3d4d86" />
<img width="554" height="563" alt="image" src="https://github.com/user-attachments/assets/b0550960-a3fe-46c6-8218-2cdfa4478a9a" />
