### PR TITLE
fix: stop resize flicker of "importing" layer/dialog

### DIFF
--- a/components/ImportGamesDialog.vue
+++ b/components/ImportGamesDialog.vue
@@ -42,7 +42,12 @@
           </li>
         </ol>
       </template>
-      <Loading v-else />
+      <template v-else>
+        <div class="flex min-h-[200px] flex-col items-center justify-center gap-4 py-8">
+          <Loading />
+          <p class="text-muted">Importing your games…</p>
+        </div>
+      </template>
     </div>
   </Dialog>
 </template>


### PR DESCRIPTION
When bulk importing from CSV I noticed that the progress indicator "flickers" as it tries to fit round alternating images.

This makes the progress area a suitable size to remove the flickering behaviour.