### PR TITLE
fix: e2e test fixes and event access improvements

### DIFF
--- a/components/CommunityTemplate.vue
+++ b/components/CommunityTemplate.vue
@@ -138,7 +138,7 @@
             You have been banned from this community.
           </p>
         </div>
-        <div v-else-if="isNotAllowed">
+        <div v-else-if="isNotAllowed && !props.publicContent">
           <p class="text-center py-3 text-stone-400">
             This community is private. You must join to view it.
           </p>
@@ -172,6 +172,7 @@ import { Status } from "@/composables/useFetchStatus";
 const props = defineProps<{
   moderatorOnly?: boolean;
   slug?: string;
+  publicContent?: boolean;
 }>();
 
 const slug = (route.params.slug || props.slug) as string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10774,23 +10774,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/crossws": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.4.tgz",
-      "integrity": "sha512-w6c4OdpRNnudVmcgr7brb/+/HmYjMQvYToO/oTrprTwxRUiom3LYWU1PMWuD006okbUWpII1Ea9/+kwpUfmyRg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "srvx": ">=0.7.1"
-      },
-      "peerDependenciesMeta": {
-        "srvx": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "db:reset": "supabase db reset && prisma migrate reset --force && prisma db seed",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
-    "postinstall": "nuxt prepare && prisma generate",
+    "postinstall": "nuxt prepare && prisma generate && node scripts/patch-prisma.js",
     "test": "playwright test",
     "build:capacitor": "CAPACITOR_BUILD=true nuxt generate",
     "cap:sync": "npx cap sync",

--- a/pages/e/[event_short_code].vue
+++ b/pages/e/[event_short_code].vue
@@ -11,8 +11,8 @@ const router = useRouter();
 const route = useRoute();
 const response = await useFetch(`/api/e/${route.params.event_short_code}`);
 
-if (response.data) {
-  router.push(response.data.value!);
+if (response.data?.value) {
+  router.push(response.data.value);
 } else {
   router.push("/404");
 }

--- a/pages/event/[eventId]/index.vue
+++ b/pages/event/[eventId]/index.vue
@@ -4,6 +4,10 @@
     :slug="
       event.status === Status.SUCCESS ? event.data.community?.slug : undefined
     "
+    :publicContent="
+      event.status === Status.SUCCESS &&
+      ['ANYONE', 'PRIVATE'].includes(event.data.who_can_register)
+    "
   >
     <template v-if="event.status === Status.SUCCESS">
       <UserHeader

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, devices } from "@playwright/test";
-import { fileURLToPath } from "node:url";
 import type { ConfigOptions } from "@nuxt/test-utils/playwright";
+import 'dotenv/config';
 
 export default defineConfig<ConfigOptions>({
   globalSetup: require.resolve("./tests/e2e/global.setup.ts"),

--- a/scripts/patch-prisma.js
+++ b/scripts/patch-prisma.js
@@ -1,0 +1,11 @@
+// Workaround for Prisma v7 + Playwright incompatibility
+// Prisma sets globalThis['__dirname'] which tricks Playwright into CJS mode
+// https://github.com/prisma/prisma/issues/28838
+const fs = require("fs");
+const path = require("path");
+const file = path.join(__dirname, "..", "server", "generated", "prisma", "client.ts");
+fs.writeFileSync(
+  file,
+  fs.readFileSync(file, "utf8").replace(/globalThis\['__dirname'\].*\n/, "")
+);
+console.log(`✔ Removed globalThis['__dirname'] from Prisma file at ${file}`);

--- a/server/api/e/[event_short_code].get.ts
+++ b/server/api/e/[event_short_code].get.ts
@@ -1,40 +1,11 @@
-import type { SupabaseUser as User } from "~/server/utils/supabaseUser";
 import { prisma } from "~/server/utils/prisma";
 
 export default defineEventHandler(async (handler) => {
-  const me: User | null = handler.context.user;
   const event_short_code = handler.context.params!.event_short_code;
 
   const event = await prisma.event.findUnique({
     where: {
       short_link: event_short_code,
-      OR: [
-        {
-          community_id: null,
-        },
-        {
-          community: {
-            banned_users: {
-              none: {
-                user_id: me?.id || "",
-              },
-            },
-            OR: [
-              {
-                is_private: false,
-              },
-              {
-                members: {
-                  some: {
-                    user_id: me?.id || "",
-                  },
-                },
-                is_private: true,
-              },
-            ],
-          },
-        },
-      ],
     },
     select: {
       id: true,

--- a/server/api/event/[event_id].get.ts
+++ b/server/api/event/[event_id].get.ts
@@ -35,6 +35,18 @@ export default defineEventHandler(async (handler) => {
           ],
         },
         {
+          who_can_register: {
+            in: [WhoCanRegister.ANYONE, WhoCanRegister.PRIVATE],
+          },
+          community: {
+            banned_users: {
+              none: {
+                user_id: me?.id || "",
+              },
+            },
+          },
+        },
+        {
           community: {
             banned_users: {
               none: {

--- a/tests/e2e/event-access.spec.ts
+++ b/tests/e2e/event-access.spec.ts
@@ -1,0 +1,173 @@
+import { test, expect } from "@playwright/test";
+import { PrismaClient } from "../../server/generated/prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { nanoid } from "nanoid";
+
+const oneDay = 1000 * 60 * 60 * 24;
+const oneHour = 1000 * 60 * 60;
+
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
+const prisma = new PrismaClient({ adapter });
+
+type CommunityType = "public" | "private" | "none";
+type WhoCanRegister = "ANYONE" | "PRIVATE" | "COMMUNITY_MEMBERS";
+
+type Fixture = {
+  id: string;
+  title: string;
+  shortCode: string;
+  communityType: CommunityType;
+  whoCanRegister: WhoCanRegister;
+  expectVisible: boolean;
+};
+
+const fixtures: Fixture[] = [];
+let publicCommunityId: number;
+let privateCommunityId: number;
+
+// COMMUNITY_MEMBERS events are only accessible to unauthenticated users when the
+// community is public (open to everyone). For private communities the user must be
+// a member, and for no-community events the user must be a friend of the creator.
+// ANYONE and PRIVATE (direct link) events are always accessible regardless of community privacy.
+function expectVisible(ct: CommunityType, wcr: WhoCanRegister): boolean {
+  if (wcr === "COMMUNITY_MEMBERS" && ct !== "public") return false;
+  return true;
+}
+
+test.beforeAll(async () => {
+  const tag = nanoid(6);
+
+  const publicCommunity = await prisma.community.create({
+    data: {
+      name: `E2E Public ${tag}`,
+      slug: `e2e-pub-${tag}`,
+      description: "Test community",
+      icon: "/img/default.png",
+      is_private: false,
+    },
+  });
+  publicCommunityId = publicCommunity.id;
+
+  const privateCommunity = await prisma.community.create({
+    data: {
+      name: `E2E Private ${tag}`,
+      slug: `e2e-priv-${tag}`,
+      description: "Test community",
+      icon: "/img/default.png",
+      is_private: true,
+    },
+  });
+  privateCommunityId = privateCommunity.id;
+
+  const communityIds: Record<CommunityType, number | null> = {
+    public: publicCommunityId,
+    private: privateCommunityId,
+    none: null,
+  };
+
+  const communityTypes: CommunityType[] = ["public", "private", "none"];
+  const registerTypes: WhoCanRegister[] = [
+    "ANYONE",
+    "PRIVATE",
+    "COMMUNITY_MEMBERS",
+  ];
+
+  for (const ct of communityTypes) {
+    for (const wcr of registerTypes) {
+      const sc = nanoid(8);
+      const title = `E2E-${ct}-${wcr}-${tag}`;
+      const start = new Date(Date.now() + oneDay);
+      const end = new Date(Date.now() + oneDay + oneHour);
+
+      const event = await prisma.event.create({
+        data: {
+          title,
+          description: "Test event",
+          start,
+          end,
+          location: "Test Location",
+          community_id: communityIds[ct],
+          who_can_register: wcr,
+          short_link: sc,
+        },
+      });
+
+      fixtures.push({
+        id: event.id,
+        title,
+        shortCode: sc,
+        communityType: ct,
+        whoCanRegister: wcr,
+        expectVisible: expectVisible(ct, wcr),
+      });
+    }
+  }
+});
+
+test.afterAll(async () => {
+  for (const f of fixtures) {
+    await prisma.event.delete({ where: { id: f.id } }).catch(() => {});
+  }
+  await prisma.community
+    .delete({ where: { id: publicCommunityId } })
+    .catch(() => {});
+  await prisma.community
+    .delete({ where: { id: privateCommunityId } })
+    .catch(() => {});
+  await prisma.$disconnect();
+});
+
+test.describe("Event access - unauthenticated", () => {
+  test("event detail API returns correct status for each combination", async ({
+    request,
+  }) => {
+    for (const f of fixtures) {
+      const expected = f.expectVisible ? 200 : 404;
+      await test.step(`${f.communityType} + ${f.whoCanRegister} → ${expected}`, async () => {
+        const res = await request.get(`/api/event/${f.id}`);
+        expect(res.status()).toBe(expected);
+      });
+    }
+  });
+
+  test("short code API resolves all events regardless of access", async ({
+    request,
+  }) => {
+    for (const f of fixtures) {
+      await test.step(`${f.communityType} + ${f.whoCanRegister}`, async () => {
+        const res = await request.get(`/api/e/${f.shortCode}`);
+        expect(res.status()).toBe(200);
+        expect(await res.text()).toContain(`/event/${f.id}/`);
+      });
+    }
+  });
+
+  test("invalid short code returns 404, not 500", async ({ request }) => {
+    const res = await request.get("/api/e/nonexistent_code");
+    expect(res.status()).toBe(404);
+  });
+
+  test("accessible events render via short link", async ({ page }) => {
+    for (const f of fixtures.filter((f) => f.expectVisible)) {
+      await test.step(`${f.communityType} + ${f.whoCanRegister}`, async () => {
+        await page.goto(`/e/${f.shortCode}`);
+        await expect(page.getByText(f.title).first()).toBeVisible({
+          timeout: 15000,
+        });
+      });
+    }
+  });
+
+  test("inaccessible COMMUNITY_MEMBERS events do not render via short link", async ({
+    page,
+  }) => {
+    for (const f of fixtures.filter((f) => !f.expectVisible)) {
+      await test.step(`${f.communityType} + ${f.whoCanRegister}`, async () => {
+        await page.goto(`/e/${f.shortCode}`);
+        await page.waitForURL(/\/event\//);
+        await page.waitForLoadState("networkidle");
+        await expect(page.getByText(f.title)).not.toBeVisible();
+      });
+    }
+  });
+});

--- a/tests/e2e/maintenance.spec.ts
+++ b/tests/e2e/maintenance.spec.ts
@@ -25,7 +25,7 @@ test.describe("Maintenance Page", () => {
     // Verify the image is present by checking its alt text or src if more specific
     // For example, if the image always has this src:
     await expect(
-      page.locator('img[src="/img/role/engineer.webp"]')
+      page.locator('img[src^="/img/ui/tinker_large.webp"]')
     ).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary

- **Event access**: Allow `ANYONE`/`PRIVATE` (direct link) events in communities to be viewed regardless of community privacy (as long as user is not banned). Previously these were gated behind community membership checks.
- **Short code API**: Remove access control from the short code resolver. It now resolves all events to their detail URL, where visibility is enforced. Fixes null pointer on the short code page.
- **CommunityTemplate**: Add `publicContent` prop so `ANYONE`/`PRIVATE` events can render inside private community templates without hitting the "must join" gate.
- **Maintenance test**: Fix image selector to match actual `ImageUI` component output (`/img/ui/tinker_large.webp`).
- **Prisma v7 + Playwright compat**: Add `scripts/patch-prisma.js` post-generate hook that strips the `globalThis['__dirname']` line from the generated client, working around [prisma/prisma#28838](https://github.com/prisma/prisma/issues/28838).
- **New e2e tests**: `event-access.spec.ts` covering all 9 community type × registration type combinations for both API and browser rendering.

## Disclosure

Claude Opus 4.6 was used to write the code, but independent review was done by myself and I tested the project locally confirming it worked as I expected. Please feel free to discuss if this is not the intended behaviour you are looking for.